### PR TITLE
Adding dev-db/sqlcipher dependency; build fails without it (4.0.1 works)

### DIFF
--- a/net-im/riot-desktop/riot-desktop-1.6.1.ebuild
+++ b/net-im/riot-desktop/riot-desktop-1.6.1.ebuild
@@ -19,7 +19,8 @@ REQUIRED_USE=""
 
 RESTRICT="network-sandbox"
 
-RDEPEND="dev-libs/nss
+RDEPEND="dev-db/sqlcipher
+	dev-libs/nss
 	>=net-libs/nodejs-12.14.0
 	net-print/cups
 	x11-libs/libXScrnSaver


### PR DESCRIPTION
Maintained alphabetical dependency ordering. Let me know if there's anything else I need to do.